### PR TITLE
feat: 新增登入頁與 minimal layout 重構

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,5 +1,3 @@
-<script setup lang="ts"></script>
-
 <template>
   <UApp>
     <NuxtLayout>

--- a/app/app.vue
+++ b/app/app.vue
@@ -1,68 +1,9 @@
-<script setup lang="ts">
-import type { NavigationMenuItem } from '@nuxt/ui'
-
-const route = useRoute()
-const menuItems = computed<NavigationMenuItem[]>(() => [
-  { label: '首頁', to: '/' },
-  { label: '文章', to: '/articles', active: route.path.startsWith('/articles') },
-])
-</script>
+<script setup lang="ts"></script>
 
 <template>
   <UApp>
-    <UHeader>
-      <template #title>
-        <img src="/logo2.webp" class="h-12" alt="Logo" aria-label="Logo" />
-      </template>
-
-      <UNavigationMenu
-        :items="menuItems"
-        variant="link"
-        :ui="{
-          link: 'text-lg',
-        }"
-      />
-
-      <template #right>
-        <UColorModeButton size="xl" />
-        <UButton
-          color="neutral"
-          variant="ghost"
-          to="https://github.com/st-avi"
-          target="_blank"
-          icon="i-simple-icons-github"
-          aria-label="GitHub"
-          size="xl"
-        />
-      </template>
-
-      <template #body>
-        <UNavigationMenu
-          :items="menuItems"
-          orientation="vertical"
-          class="-mx-2.5"
-          :ui="{
-            link: 'text-lg',
-          }"
-        />
-      </template>
-    </UHeader>
-
-    <UMain>
-      <NuxtLayout>
-        <NuxtPage />
-      </NuxtLayout>
-    </UMain>
-
-    <UFooter class="border-default border-t">
-      <template #left>
-        <p class="text-muted text-sm">Copyright &copy; {{ new Date().getFullYear() }} Stavi. 保留一切權利。</p>
-      </template>
-      <template #right>
-        <div class="flex">
-          <ULink class="text-sm">使用條款</ULink>
-        </div>
-      </template>
-    </UFooter>
+    <NuxtLayout>
+      <NuxtPage />
+    </NuxtLayout>
   </UApp>
 </template>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import type { NavigationMenuItem } from '@nuxt/ui'
+
+const route = useRoute()
+const menuItems = computed<NavigationMenuItem[]>(() => [
+  { label: '首頁', to: '/' },
+  { label: '文章', to: '/articles', active: route.path.startsWith('/articles') },
+])
+</script>
+
+<template>
+  <div>
+    <UHeader>
+      <template #title>
+        <img src="/logo2.webp" class="h-12" alt="Logo" aria-label="Logo" />
+      </template>
+
+      <UNavigationMenu
+        :items="menuItems"
+        variant="link"
+        :ui="{
+          link: 'text-lg',
+        }"
+      />
+
+      <template #right>
+        <UColorModeButton size="xl" />
+        <UButton
+          color="neutral"
+          variant="ghost"
+          to="https://github.com/st-avi"
+          target="_blank"
+          icon="i-simple-icons-github"
+          aria-label="GitHub"
+          size="xl"
+        />
+      </template>
+
+      <template #body>
+        <UNavigationMenu
+          :items="menuItems"
+          orientation="vertical"
+          class="-mx-2.5"
+          :ui="{
+            link: 'text-lg',
+          }"
+        />
+      </template>
+    </UHeader>
+
+    <UMain>
+      <slot />
+    </UMain>
+
+    <UFooter class="border-default border-t">
+      <template #left>
+        <p class="text-muted text-sm">Copyright &copy; {{ new Date().getFullYear() }} Stavi. 保留一切權利。</p>
+      </template>
+      <template #right>
+        <div class="flex">
+          <ULink class="text-sm">使用條款</ULink>
+        </div>
+      </template>
+    </UFooter>
+  </div>
+</template>

--- a/app/layouts/minimal.vue
+++ b/app/layouts/minimal.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="flex min-h-screen flex-col items-center justify-center p-4">
+    <slot />
+  </div>
+</template>

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import * as z from 'zod'
+import type { FormSubmitEvent, AuthFormField } from '@nuxt/ui'
+
+definePageMeta({
+  layout: 'minimal',
+})
+
+const schema = z.object({
+  email: z.string().email('請輸入有效的信箱'),
+  password: z.string().min(1, '請輸入密碼').min(8, '密碼至少需要 8 個字元'),
+})
+
+type Schema = z.output<typeof schema>
+
+const fields: AuthFormField[] = [
+  {
+    name: 'email',
+    type: 'email',
+    label: '信箱',
+    placeholder: '請輸入您的信箱',
+    required: true,
+  },
+  {
+    name: 'password',
+    type: 'password',
+    label: '密碼',
+    placeholder: '請輸入您的密碼',
+    required: true,
+  },
+]
+
+const handleGoogleLogin = () => {
+  // TODO: 串接 Google OAuth API
+}
+
+const providers = [
+  {
+    label: 'Google',
+    icon: 'i-simple-icons-google',
+    onClick: handleGoogleLogin,
+  },
+]
+
+const handleSubmit = (payload: FormSubmitEvent<Schema>) => {
+  // TODO: 串接登入 API
+  console.log('Submitted', payload)
+}
+</script>
+
+<template>
+  <UPageCard class="w-full max-w-md">
+    <UAuthForm
+      :schema="schema"
+      title="登入"
+      description="輸入您的帳號憑證以存取您的帳戶。"
+      icon="i-lucide-user"
+      :fields="fields"
+      :providers="providers"
+      :submit="{ label: '登入', block: true }"
+      @submit="handleSubmit"
+    />
+  </UPageCard>
+</template>

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -7,8 +7,8 @@ definePageMeta({
 })
 
 const schema = z.object({
-  email: z.string().email('請輸入有效的信箱'),
-  password: z.string().min(1, '請輸入密碼').min(8, '密碼至少需要 8 個字元'),
+  email: z.string().email('請輸入有效的電子郵件地址'),
+  password: z.string().min(1, '請輸入密碼').min(12, '密碼至少需要 12 個字元'),
 })
 
 type Schema = z.output<typeof schema>
@@ -17,16 +17,14 @@ const fields: AuthFormField[] = [
   {
     name: 'email',
     type: 'email',
-    label: '信箱',
-    placeholder: '請輸入您的信箱',
-    required: true,
+    label: '電子郵件地址',
+    placeholder: '請輸入您的電子郵件地址',
   },
   {
     name: 'password',
     type: 'password',
     label: '密碼',
     placeholder: '請輸入您的密碼',
-    required: true,
   },
 ]
 
@@ -53,7 +51,7 @@ const handleSubmit = (payload: FormSubmitEvent<Schema>) => {
     <UAuthForm
       :schema="schema"
       title="登入"
-      description="輸入您的帳號憑證以存取您的帳戶。"
+      description="輸入您的電子郵件地址和密碼以登入您的帳戶。"
       icon="i-lucide-user"
       :fields="fields"
       :providers="providers"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@nuxt/eslint": "1.13.0",
+    "zod": "^3.24.0",
     "@nuxt/ui": "^4.4.0",
     "@tailwindcss/vite": "^4.1.18",
     "eslint": "^9.39.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 1.13.0(@typescript-eslint/utils@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.27)(eslint@9.39.2(jiti@2.6.1))(magicast@0.5.2)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))
       '@nuxt/ui':
         specifier: ^4.4.0
-        version: 4.4.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(change-case@5.4.4)(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.9.2)(magicast@0.5.2)(tailwindcss@4.1.18)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))(vue-router@5.0.2(@vue/compiler-sfc@3.5.27)(vue@3.5.27(typescript@5.9.3)))(vue@3.5.27(typescript@5.9.3))(yjs@13.6.29)
+        version: 4.4.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(change-case@5.4.4)(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.9.2)(magicast@0.5.2)(tailwindcss@4.1.18)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))(vue-router@5.0.2(@vue/compiler-sfc@3.5.27)(vue@3.5.27(typescript@5.9.3)))(vue@3.5.27(typescript@5.9.3))(yjs@13.6.29)(zod@3.25.76)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))
@@ -35,6 +35,9 @@ importers:
       vue-router:
         specifier: ^5.0.2
         version: 5.0.2(@vue/compiler-sfc@3.5.27)(vue@3.5.27(typescript@5.9.3))
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
     devDependencies:
       eslint-config-prettier:
         specifier: ^10.1.8
@@ -5527,6 +5530,9 @@ packages:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -6531,7 +6537,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/ui@4.4.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(change-case@5.4.4)(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.9.2)(magicast@0.5.2)(tailwindcss@4.1.18)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))(vue-router@5.0.2(@vue/compiler-sfc@3.5.27)(vue@3.5.27(typescript@5.9.3)))(vue@3.5.27(typescript@5.9.3))(yjs@13.6.29)':
+  '@nuxt/ui@4.4.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(change-case@5.4.4)(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.9.2)(magicast@0.5.2)(tailwindcss@4.1.18)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))(vue-router@5.0.2(@vue/compiler-sfc@3.5.27)(vue@3.5.27(typescript@5.9.3)))(vue@3.5.27(typescript@5.9.3))(yjs@13.6.29)(zod@3.25.76)':
     dependencies:
       '@floating-ui/dom': 1.7.5
       '@iconify/vue': 5.0.0(vue@3.5.27(typescript@5.9.3))
@@ -6601,6 +6607,7 @@ snapshots:
       vue-component-type-helpers: 3.2.4
     optionalDependencies:
       vue-router: 5.0.2(@vue/compiler-sfc@3.5.27)(vue@3.5.27(typescript@5.9.3))
+      zod: 3.25.76
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -11322,3 +11329,5 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
+
+  zod@3.25.76: {}


### PR DESCRIPTION
## 變更摘要

- 新增 `/login` 登入頁（Google OAuth 按鈕、信箱、密碼、登入按鈕）
- 將 app.vue 的 layout 抽離為 `layouts/default.vue`
- 新增 `layouts/minimal.vue` ，供登入等 auth 頁面使用，避免導覽等元素干擾
- 新增 zod  dependency 供表單 schema 驗證使用

## 補充

- `handleGoogleLogin` 與 `handleSubmit` 已預留 TODO，待後續串接 API